### PR TITLE
breaking(0.5.0): include all model names in relation check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.5.0] - 2025-06-04
+
+### Changed
+
+- Ignore relation fields including model references within models
+
 ## [0.4.0] - 2025-06-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,7 +670,7 @@ dependencies = [
 
 [[package]]
 name = "prisma-rust-schema"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bson",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prisma-rust-schema"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 authors = ["Shaun Hamilton <shauhami020@gmail.com>"]
 description = "A Rust proc-macro to generate Rust types from Prisma schema files."

--- a/prisma/no-annotation-schema.prisma
+++ b/prisma/no-annotation-schema.prisma
@@ -10,19 +10,20 @@ model User {
   permission Permission
   createdAt  DateTime   @default(now())
   status     Json
-  badCase    badCase[]
 
-  posts Post[]
+  badCase badCase[]
+  posts   Post[]
 }
 
 model Post {
-  id       String  @id @default(auto()) @map("_id") @db.ObjectId
-  /// A skipped field
-  title    String
-  content  Content
-  authorId String  @db.ObjectId
+  id        String  @id @default(auto()) @map("_id") @db.ObjectId
+  title     String
+  content   Content
+  authorId  String  @db.ObjectId
+  badCaseId String  @db.ObjectId
 
-  author User @relation(fields: [authorId], references: [id])
+  author  User    @relation(fields: [authorId], references: [id])
+  badCase badCase @relation(fields: [badCaseId], references: [id])
 }
 
 /// Permission for `User`
@@ -43,7 +44,8 @@ model badCase {
   id     String @id @default(auto()) @map("_id") @db.ObjectId
   userId String @db.ObjectId
 
-  User User @relation(fields: [userId], references: [id])
+  User  User   @relation(fields: [userId], references: [id])
+  posts Post[]
 }
 
 /// A skipped enum

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ fn handle_import(item: proc_macro::TokenStream) -> syn::Result<proc_macro::Token
     // let mut output_token_stream = TokenStream::new();
     let mut output_tokens = quote! {};
 
-    for top in tops {
+    for top in &tops {
         match top {
             Top::CompositeType(composite_type) => {
                 let name = composite_type.name();
@@ -135,7 +135,9 @@ fn handle_import(item: proc_macro::TokenStream) -> syn::Result<proc_macro::Token
                 let struct_name = format_ident!("{}", name);
 
                 let documentation = extract_docs(composite_type.documentation().clone());
-                let fields = composite_type.iter_fields().filter_map(handle_fields);
+                let fields = composite_type
+                    .iter_fields()
+                    .filter_map(|(_field_id, field)| handle_fields(&tops, field));
 
                 let derive = handle_derive(derive);
 
@@ -274,7 +276,9 @@ fn handle_import(item: proc_macro::TokenStream) -> syn::Result<proc_macro::Token
                 };
                 let struct_name = format_ident!("{}", name);
                 let documentation = extract_docs(model.documentation().clone());
-                let fields = model.iter_fields().filter_map(handle_fields);
+                let fields = model
+                    .iter_fields()
+                    .filter_map(|(_field_id, field)| handle_fields(&tops, field));
 
                 let derive = handle_derive(derive);
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -17,8 +17,6 @@ fn user_model() {
             "active": true,
             "lastLogin": 1234567890,
         },
-        "badCase": [],
-        "posts": []
     });
 
     let user: User = serde_json::from_value(user_json).unwrap();
@@ -38,8 +36,6 @@ fn user_model() {
         user.status,
         json!({"active": true, "lastLogin": 1234567890})
     );
-    assert_eq!(user.bad_case, vec![]);
-    assert_eq!(user.posts, vec![]);
 }
 
 #[test]

--- a/tests/import_options.rs
+++ b/tests/import_options.rs
@@ -18,8 +18,6 @@ fn user_model() {
             "active": true,
             "lastLogin": 1234567890,
         },
-        "badCase": [],
-        "posts": []
     });
 
     let user: AUser = serde_json::from_value(user_json).unwrap();
@@ -42,8 +40,6 @@ fn user_model() {
         user.status,
         json!({"active": true, "lastLogin": 1234567890})
     );
-    assert_eq!(user.bad_case, vec![]);
-    assert_eq!(user.posts, vec![]);
 }
 
 #[test]
@@ -63,6 +59,9 @@ fn post_model() {
             "$oid": "507f1f77bcf86cd799439012"
         },
         "title": "Sample Post",
+        "badCaseId": {
+            "$oid": "507f1f77bcf86cd799439013"
+        }
     });
 
     let post: APost = serde_json::from_value(post_json).unwrap();
@@ -83,6 +82,10 @@ fn post_model() {
         ObjectId::parse_str("507f1f77bcf86cd799439012").unwrap()
     );
     assert_eq!(post.title, "Sample Post".to_string());
+    assert_eq!(
+        post.bad_case_id,
+        ObjectId::parse_str("507f1f77bcf86cd799439013").unwrap()
+    );
 }
 
 #[test]
@@ -96,7 +99,8 @@ fn bad_case_model() {
         }
     });
 
-    let bad_case: ABadCase = serde_json::from_value(bad_case_json).unwrap();
+    let bad_case: ABadCase = serde_json::from_value(bad_case_json)
+        .expect("deserialization failed. ensure `posts` field is IGNORED");
     assert_eq!(
         bad_case.id,
         ObjectId::parse_str("507f1f77bcf86cd799439011").unwrap()


### PR DESCRIPTION
This seems like the correct fix, but might be reverted/changed if determined otherwise.